### PR TITLE
feat: add text compressor tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,216 @@
+# AGENTS.md
+
+Purpose: quick, evidence-based onboarding for agentic coding assistants in this repo.
+
+Repository summary
+
+- Vue 3 + Vite app (TypeScript) with pnpm.
+- Tool catalog lives under src/tools; UI components under src/ui and src/components.
+
+If you’re looking for Cursor/Copilot rules
+
+- No .cursorrules or .cursor/rules/\*\* found.
+- No .github/copilot-instructions.md found.
+
+---
+
+## 1) Essential commands
+
+Package manager
+
+- pnpm (see package.json: "packageManager": "pnpm@10.17.1" and pnpm-lock.yaml)
+
+Install
+
+- pnpm install
+
+Dev server
+
+- pnpm dev
+
+Build / preview
+
+- pnpm build
+- pnpm preview --port 5050
+
+Lint / typecheck
+
+- pnpm lint
+- pnpm typecheck
+
+Tests (unit / e2e / coverage)
+
+- pnpm test (alias to test:unit)
+- pnpm run test:unit
+- pnpm run test:e2e
+- pnpm run test:e2e:dev
+- pnpm run coverage
+
+Other scripts
+
+- pnpm run script:create:tool my-tool-name
+- pnpm run script:create:ui
+
+---
+
+## 2) Single-test patterns
+
+Unit (Vitest)
+
+- This repo uses Vitest; run a single test via Vitest CLI options.
+  Example patterns (Vitest standard):
+  - pnpm vitest path/to/test-file
+  - pnpm vitest -t "test name"
+    (No repo-specific single-test script found.)
+
+E2E (Playwright)
+
+- playright.config.ts is set up with testDir: ./src and testMatch: \*.e2e.(spec.)ts.
+- Run a single spec or test using Playwright CLI options:
+  - pnpm run test:e2e -- path/to/spec.e2e.spec.ts
+  - pnpm run test:e2e -- --grep "test name"
+    (No repo-specific single-test script found.)
+
+---
+
+## 3) CI / automation references
+
+CI workflow (GitHub Actions)
+
+- .github/workflows/ci.yml
+  - pnpm i
+  - pnpm lint
+  - pnpm test
+  - pnpm typecheck
+  - pnpm build
+
+E2E workflow
+
+- .github/workflows/e2e-tests.yml
+  - pnpm install
+  - pnpm build
+  - pnpm exec playwright install --with-deps
+  - pnpm run test:e2e --shard=${{ matrix.shard }}
+
+Docker build
+
+- Dockerfile runs pnpm build in build stage.
+
+---
+
+## 4) Formatting & linting rules (evidence-based)
+
+Prettier (.prettierrc)
+
+- singleQuote: true
+- semi: true
+- tabWidth: 2
+- trailingComma: all
+- printWidth: 120
+
+ESLint (.eslintrc.cjs)
+
+- curly: ["error", "all"] (always use braces)
+- @typescript-eslint/semi: ["error", "always"]
+- @typescript-eslint/no-use-before-define enabled; allowNamedExports: true, functions: false
+- no-restricted-imports: do not import useClipboard from @vueuse/core
+  - Use local useCopy from src/composable/copy.ts instead
+
+Auto-import globals (.eslintrc-auto-import.json)
+
+- Vue / VueUse / vue-router / vue-i18n APIs are globally available for linting.
+- Still import explicitly when clarity matters or when not auto-imported.
+
+---
+
+## 5) TypeScript + project structure
+
+TypeScript configuration
+
+- Root tsconfig.json references:
+  - tsconfig.app.json (app code)
+  - tsconfig.vite-config.json (Vite config)
+  - tsconfig.vitest.json (tests)
+- App tsconfig uses alias "@/_" -> "./src/_".
+
+Vite config highlights (vite.config.ts)
+
+- Auto-imports Vue / vue-router / @vueuse/core / vue-i18n / naive-ui hooks
+- Components auto-registered from src/ and .md
+- Vitest config excludes \*_/_.e2e.spec.ts
+
+---
+
+## 6) Code style conventions (from repo examples)
+
+Imports
+
+- Use named imports; group logically.
+- Use "import type" for type-only imports (see src/tools/index.ts).
+- Alias tool imports as `tool as <name>` in src/tools/index.ts:
+  - import { tool as uuidGenerator } from './uuid-generator';
+
+Naming
+
+- Composables use `useX` naming (useCopy, useValidation, useToolStore).
+- Types / interfaces use PascalCase.
+- Variables and functions use camelCase.
+
+Error handling
+
+- Prefer throwing Error objects (throw new Error('...')) in production code.
+- Use shared helpers for normalization:
+  - getErrorMessageIfThrows in src/utils/error.ts
+- Validation wraps errors and treats thrown values as failures
+  (see src/composable/validation.ts).
+
+Vue SFC patterns
+
+- Use <script setup lang="ts">.
+- Use Composition API (computed, ref, watch, etc.).
+- Less is used for scoped styles in many components.
+
+---
+
+## 7) Testing notes
+
+Unit tests
+
+- Vitest with jsdom environment (package.json: test:unit).
+
+E2E tests
+
+- Playwright config at playwright.config.ts.
+- Base URL default: http://localhost:5050 (unless BASE_URL is set).
+- testIdAttribute is "data-test-id".
+
+---
+
+## 8) Common pitfalls & repo-specific rules
+
+- Do NOT use @vueuse/core useClipboard directly; use local useCopy.
+- Keep semicolons; curly braces required for all blocks.
+- Follow Prettier rules (single quotes, trailing commas, print width 120).
+
+---
+
+## 9) When adding a new tool
+
+- Use script: pnpm run script:create:tool my-tool-name
+- Tools live in src/tools and are listed in src/tools/index.ts by category.
+- Add tool to correct category array in toolsByCategory.
+
+---
+
+## 10) Evidence references (key files)
+
+- package.json (scripts + tooling)
+- README.md (developer commands)
+- .prettierrc, .eslintrc.cjs, .eslintrc-auto-import.json
+- tsconfig.json / tsconfig.app.json / tsconfig.vitest.json / tsconfig.vite-config.json
+- vite.config.ts
+- playwright.config.ts
+- src/tools/index.ts (import style + tool registration)
+- src/composable/validation.ts (error handling + validation patterns)
+- src/utils/error.ts (error normalization helper)
+- src/composable/copy.ts (useCopy, restricted import)

--- a/components.d.ts
+++ b/components.d.ts
@@ -205,6 +205,7 @@ declare module '@vue/runtime-core' {
     'SvgPreview.tool': typeof import('./src/tools/svg-preview/svg-preview.tool.vue')['default']
     TemperatureConverter: typeof import('./src/tools/temperature-converter/temperature-converter.vue')['default']
     TextareaCopyable: typeof import('./src/components/TextareaCopyable.vue')['default']
+    TextCompressor: typeof import('./src/tools/text-compressor/text-compressor.vue')['default']
     TextDiff: typeof import('./src/tools/text-diff/text-diff.vue')['default']
     TextStatistics: typeof import('./src/tools/text-statistics/text-statistics.vue')['default']
     TextToBinary: typeof import('./src/tools/text-to-binary/text-to-binary.vue')['default']

--- a/docs/plans/2026-02-12-text-compressor-design.md
+++ b/docs/plans/2026-02-12-text-compressor-design.md
@@ -1,0 +1,76 @@
+# Text Compressor Tool Design
+
+**Goal:** Add a new tool that compresses text into a single line by removing newline characters, trimming leading/trailing spaces or tabs on each line, and inserting a single space between lines to avoid word concatenation.
+
+**Architecture:** Implement as a standard text-transform tool using the shared `FormatTransformer` component. Keep transformation logic in a pure service function for easy unit testing. Register the tool in the existing tool index and localization files.
+
+**Tech Stack:** Vue 3 + Vite + TypeScript, shared tool UI (`FormatTransformer`), Vitest for unit tests, Playwright for E2E.
+
+---
+
+## Scope & Behavior
+
+**Input:** Arbitrary text (may include `\n`, `\r\n`, `\r`).
+
+**Output:** Single-line text, computed as:
+
+1. Split by all newline variants (`\r\n|\r|\n`).
+2. For each line, trim **leading and trailing** spaces/tabs only (do not collapse inner whitespace).
+3. Join the trimmed lines with a **single space** between lines.
+4. Final output should not introduce extra spaces beyond the single separators; if all lines are empty/whitespace, output is an empty string.
+
+**Non-goals:** No additional options (e.g., removing double spaces), no extra UI controls, no additional formatting beyond newline removal and line-edge trimming.
+
+## UI / UX
+
+Use the shared `FormatTransformer` component (same as other simple text tools). Provide localized labels and placeholder text. No custom controls.
+
+Suggested labels:
+
+- Input label: “Your text with newlines”
+- Input placeholder: “Paste your multiline text here...”
+- Output label: “Compressed text (single line)”
+
+## Files & Changes
+
+### Create (via scaffold script)
+
+- `src/tools/text-compressor/text-compressor.vue`
+- `src/tools/text-compressor/index.ts`
+- `src/tools/text-compressor/text-compressor.service.ts`
+- `src/tools/text-compressor/text-compressor.service.test.ts`
+- `src/tools/text-compressor/text-compressor.e2e.spec.ts`
+
+### Modify
+
+- `src/tools/text-compressor/text-compressor.service.ts`
+  - Add `compressText(text: string): string` implementing the exact behavior.
+- `src/tools/text-compressor/text-compressor.vue`
+  - Wire `compressText` into `FormatTransformer`.
+- `src/tools/text-compressor/index.ts`
+  - Define tool metadata (name, description, keywords, icon, createdAt, path).
+- `src/tools/index.ts`
+  - Add the tool import (script already inserts), then add to the “Text” category array.
+- `locales/en.yml`
+  - Add tool `title` and `description` under `tools:`.
+
+## Testing
+
+### Unit (Vitest)
+
+Add tests for:
+
+- Mixed newline variants → single-line output
+- Leading/trailing spaces/tabs removed per line
+- Inner spaces preserved
+- Empty/whitespace-only input → empty string
+
+### E2E (Playwright)
+
+- Navigate to `/text-compressor`
+- Fill input with multiline text
+- Assert output equals expected single-line text with single spaces
+
+## Open Questions
+
+None.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -450,3 +450,10 @@ tools:
   text-to-binary:
     title: Text to ASCII binary
     description: Convert text to its ASCII binary representation and vice-versa.
+
+  text-compressor:
+    title: Text compressor
+    description: Compress multiline text into a single line by removing newlines and trimming each line.
+    inputLabel: Your text with newlines
+    inputPlaceholder: Paste your multiline text here...
+    outputLabel: Compressed text (single line)

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -446,3 +446,10 @@ tools:
   text-to-binary:
     title: 文本到 ASCII 二进制
     description: 将文本转换为其 ASCII 二进制表示形式，反之亦然。
+
+  text-compressor:
+    title: 文本压缩器
+    description: 通过移除换行并修剪每行首尾空白，将多行文本压缩为单行。
+    inputLabel: 包含换行的文本
+    inputPlaceholder: 在此粘贴多行文本...
+    outputLabel: 压缩后的文本（单行）

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -82,6 +82,7 @@ import { tool as svgPlaceholderGenerator } from './svg-placeholder-generator';
 import { tool as svgPreview } from './svg-preview';
 import { tool as temperatureConverter } from './temperature-converter';
 import { tool as textStatistics } from './text-statistics';
+import { tool as textCompressor } from './text-compressor';
 import { tool as tokenGenerator } from './token-generator';
 import type { ToolCategory } from './tools.types';
 import { tool as urlEncoder } from './url-encoder';
@@ -165,10 +166,10 @@ export const toolsByCategory: ToolCategory[] = [
       gitMemo,
       randomPortGenerator,
       crontabGenerator,
-        jsonViewer,
-        jsonMinify,
-        jsonToCsv,
-        jsonFieldRemover,
+      jsonViewer,
+      jsonMinify,
+      jsonToCsv,
+      jsonFieldRemover,
       sqlPrettify,
       chmodCalculator,
       dockerRunToDockerComposeConverter,
@@ -208,6 +209,7 @@ export const toolsByCategory: ToolCategory[] = [
       textDiff,
       numeronymGenerator,
       asciiTextDrawer,
+      textCompressor,
     ],
   },
   {
@@ -218,5 +220,5 @@ export const toolsByCategory: ToolCategory[] = [
 
 export const tools = toolsByCategory.flatMap(({ components }) => components);
 export const toolsWithCategory = toolsByCategory.flatMap(({ components, name }) =>
-  components.map(tool => ({ category: name, ...tool })),
+  components.map((tool) => ({ category: name, ...tool })),
 );

--- a/src/tools/text-compressor/index.ts
+++ b/src/tools/text-compressor/index.ts
@@ -1,0 +1,13 @@
+import { FileText } from '@vicons/tabler';
+import { defineTool } from '../tool';
+import { translate } from '@/plugins/i18n.plugin';
+
+export const tool = defineTool({
+  name: translate('tools.text-compressor.title'),
+  path: '/text-compressor',
+  description: translate('tools.text-compressor.description'),
+  keywords: ['text', 'compressor', 'compress', 'newline', 'single', 'line', 'remove', 'trim', 'flatten'],
+  component: () => import('./text-compressor.vue'),
+  icon: FileText,
+  createdAt: new Date('2026-02-12'),
+});

--- a/src/tools/text-compressor/text-compressor.e2e.spec.ts
+++ b/src/tools/text-compressor/text-compressor.e2e.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Tool - Text compressor', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/text-compressor');
+  });
+
+  test('Has correct title', async ({ page }) => {
+    await expect(page).toHaveTitle('Text compressor - IT Tools');
+  });
+
+  test('Compresses multiline text into a single line', async ({ page }) => {
+    await page.getByTestId('input').fill('  hello  \nworld\r\n  foo  ');
+
+    // The output is rendered by <textarea-copyable> which uses the second textarea on the page
+    const outputTextarea = page.locator('textarea').nth(1);
+    await expect(outputTextarea).toHaveValue('hello world foo');
+  });
+});

--- a/src/tools/text-compressor/text-compressor.service.test.ts
+++ b/src/tools/text-compressor/text-compressor.service.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { compressText } from './text-compressor.service';
+
+describe('text-compressor', () => {
+  describe('compressText', () => {
+    it('joins lines separated by LF with a single space', () => {
+      expect(compressText('hello\nworld')).toBe('hello world');
+    });
+
+    it('joins lines separated by CRLF with a single space', () => {
+      expect(compressText('hello\r\nworld')).toBe('hello world');
+    });
+
+    it('joins lines separated by CR with a single space', () => {
+      expect(compressText('hello\rworld')).toBe('hello world');
+    });
+
+    it('handles mixed newline variants', () => {
+      expect(compressText('line1\nline2\r\nline3\rline4')).toBe('line1 line2 line3 line4');
+    });
+
+    it('trims leading and trailing spaces and tabs from each line', () => {
+      expect(compressText('  hello  \n\tworld\t')).toBe('hello world');
+    });
+
+    it('preserves inner whitespace within a line', () => {
+      expect(compressText('hello   world\nfoo  bar')).toBe('hello   world foo  bar');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(compressText('')).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+      expect(compressText('   \n\t\n  ')).toBe('');
+    });
+
+    it('returns single line unchanged (after trim)', () => {
+      expect(compressText('  single line  ')).toBe('single line');
+    });
+
+    it('handles consecutive empty lines gracefully (no extra spaces)', () => {
+      expect(compressText('hello\n\n\nworld')).toBe('hello world');
+    });
+  });
+});

--- a/src/tools/text-compressor/text-compressor.service.ts
+++ b/src/tools/text-compressor/text-compressor.service.ts
@@ -1,0 +1,7 @@
+export function compressText(text: string): string {
+  return text
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.replace(/^[\t ]+|[\t ]+$/g, ''))
+    .filter((line) => line.length > 0)
+    .join(' ');
+}

--- a/src/tools/text-compressor/text-compressor.vue
+++ b/src/tools/text-compressor/text-compressor.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { compressText } from './text-compressor.service';
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <format-transformer
+    :transformer="compressText"
+    :input-label="t('tools.text-compressor.inputLabel')"
+    :input-placeholder="t('tools.text-compressor.inputPlaceholder')"
+    :output-label="t('tools.text-compressor.outputLabel')"
+  />
+</template>


### PR DESCRIPTION
## Summary
- add text compressor service with unit tests
- add text compressor tool page and E2E coverage
- register tool and add EN/ZH i18n strings

## Test Plan
- [x] pnpm vitest src/tools/text-compressor/text-compressor.service.test.ts --run
- [x] pnpm build
- [ ] pnpm run test:e2e -- src/tools/text-compressor/text-compressor.e2e.spec.ts (requires Playwright browsers)